### PR TITLE
Add Ondřej Surý and Otto Moerbeek as co-authors

### DIFF
--- a/draft-poisonlicious.xml
+++ b/draft-poisonlicious.xml
@@ -79,6 +79,26 @@
       </address>
     </author>
 
+    <author initials="O." surname="Sury" fullname="Ondrej Sury">
+      <organization showOnFrontPage="true">Internet Systems Consortium</organization>
+      <address>
+        <postal>
+          <country>Czech Republic</country>
+        </postal>
+        <email>ondrej@isc.org</email>
+      </address>
+    </author>
+
+    <author fullname="Otto Moerbeek" initials="O." surname="Moerbeek">
+      <organization>PowerDNS</organization>
+      <address>
+        <postal>
+          <country>NL</country>
+        </postal>
+        <email>otto.moerbeek@powerdns.com</email>
+      </address>
+    </author>
+
     <date year="2025"/>
 
     <area>General</area>


### PR DESCRIPTION
It would be good to have co-authors from the different implementations to keep them close and make sure we align.
I have recruited Ondřej Surý (from ISC) at RIPE90 and Otto Moerbeek (from PowerDNS) at the Good Weather NLNOG 2025 meeting.
Another one from Knot-Resolver would be nice.